### PR TITLE
Awaiting merge

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,6 +1,7 @@
+var UniverseModulesRelease = '0.6.3'; // eslint-disable-line no-var
 Package.describe({
     name: 'universe:modules-npm',
-    version: '0.9.6',
+    version: UniverseModulesRelease,
     // Brief, one-line summary of the package.
     summary: 'Import NPM packages on client & server, mapping dependencies on system js modules (useful for React)',
     // URL to the Git repository containing the source code for this package.
@@ -16,21 +17,20 @@ Package.registerBuildPlugin({
     sources: ['builder.js'],
     npmDependencies: {
         'browserify': '12.0.1',
-        'envify': '3.4.0',
+        //'envify': '3.4.0',
         'strip-json-comments': '2.0.0',
         'camelcase': '2.0.1',
         'npm': '3.4.1'
     }
 });
 
-Package.onUse(function (api) {
-    api.versionsFrom('1.2.0.2');
+Package.onUse(function(api) {
+    api.versionsFrom('1.2.1');
     api.use([
-        'universe:modules@0.6.1'
+        'universe:modules@' + UniverseModulesRelease,
+        'isobuild:compiler-plugin@1.0.0'
     ]);
 
-    // Use Meteor 1.2 build plugin
-    api.use('isobuild:compiler-plugin@1.0.0');
-
+    api.imply('universe:modules@' + UniverseModulesRelease);
     api.imply('promise');
 });


### PR DESCRIPTION
As I mentioned late last night in #3, I ended up fixing the errors I was having with this repository. @cristo-rabani however had beaten me to it--well that is respond before I checked back. I didn't bother trying his version by itself, but I'm certain it wouldn't have fixed one of the issues I was having. As it stands, this repo forces the user to have the **[`[hughsk/envify]`](https://github.com/hughsk/envify)** browserify transform. `envify` was causing me issues. There already is a system in place for the user to specify which transforms they would like on which npm deps. This overrides that and forces the transform regardless of what its given except for under very specific conditions when can faulty logic be bypassed. ([#L152](https://github.com/rozzzly/meteor-universe-modules-npm/blob/c082525b7bd6fedbfd196a84635df704f6155dec/builder.js#L152), [#L192](https://github.com/rozzzly/meteor-universe-modules-npm/blob/c082525b7bd6fedbfd196a84635df704f6155dec/builder.js#L192)) I don't know if arbitrarily overriding the user's input was original authors intent, or if it was just an attempt to provide a default value.I can think of many good reasons why it shouldn't be that way. So, I changed that and a few other rather minor things, _mostly stylistic stuff so `eslint` would go away lol_. Documented a good portion of it as well. And moved most of it into sexier es6 syntax.

Please take a look, test it out for yourselves. I'm sure my codes got some issues too. If/when you're ready merge this PR, I'll go through and strip out a few inline notes I left out regarding my changes / change my indent convention the creator's prefered method, etc. 

This is a really cool package. I think this is ahead of the offical MDG modules loader, which I havent used yet but am not as enthused by as [**`[universe/modules]`**](https://gitub.com/vazco/meteor-universe) + `System.js`. Good work guys!
